### PR TITLE
Removed calls to `xml_set_object()` function. MTC-30841

### DIFF
--- a/plugins/MTBlockEditor/php/init.MTBlockEditor.php
+++ b/plugins/MTBlockEditor/php/init.MTBlockEditor.php
@@ -172,7 +172,6 @@ class Parser
 
         $handler = new SAXHandler(['meta' => $meta]);
         $parser = xml_parser_create();
-        xml_set_object($parser, $handler);
         xml_set_element_handler($parser, [$handler, 'start_element'], [$handler, 'end_element']);
         xml_set_character_data_handler($parser, [$handler, 'characters']);
         xml_parse($parser, "<xml>$content</xml>");


### PR DESCRIPTION
`xml_set_object()` is deprecated as of PHP 8.4.0
https://www.php.net/manual/function.xml-set-object.php

In our usage, the deletion does not cause any change in behavior, so we simply remove it.